### PR TITLE
Add Jekyll-Twitch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'type-on-strap'
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem 'jekyll-feed', '~> 0.12'
+  gem 'jekyll-twitch'
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.7.1)
       jekyll (>= 3.8, < 5.0)
+    jekyll-twitch (0.1.1)
+      jekyll
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.3.1)
@@ -93,6 +95,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.2.0)
   jekyll-feed (~> 0.12)
+  jekyll-twitch
   rubocop
   type-on-strap
   tzinfo (~> 1.2)

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ theme: type-on-strap
 plugins:
   - jekyll-feed
   - jekyll-paginate
+  - jekyll-twitch
 
 # SEO
 author: ChaelCodes
@@ -28,7 +29,7 @@ description: >- # this means to ignore newlines until "baseurl:"
   open-source repo for playing games of Monster of the Week. Currently,
   she works as a Developer Relations Engineer for New Relic.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "https://chael.codes" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://www.chael.codes" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: ChaelCodes
 github_username:  ChaelCodes
 

--- a/_posts/2021-03-11-research-for-a-jekyll-profile-on-github-pages.md
+++ b/_posts/2021-03-11-research-for-a-jekyll-profile-on-github-pages.md
@@ -41,4 +41,4 @@ Plugins, tools, and deploys are all great, but they're nothing without the conte
 
 I can foresee a future where I gather Twitch + Youtube + Blog content around games I'm playing, but that's the future! Not for today! (I think a Games directory with a post page for each would be cool though...)
 
-With that all the research done, I should be ready to build my first Jekyll site! I'll be streaming it [on Twitch](https://twitch.tv/ChaelCodes?utm_source=theRelicans&utm_medium=blog&utm_campaign=friday_plan) at 15:00 UTC, March 12th, and I'll report back with everything I learned!
+{% twitch https://www.twitch.tv/chaelcodes/clip/NurturingEphemeralLegKreygasm-pZLTOLAGhV8sHP7Z %}

--- a/_posts/2021-03-18-jekyll-twitch-the-gem.md
+++ b/_posts/2021-03-18-jekyll-twitch-the-gem.md
@@ -17,12 +17,12 @@ This project breaks down into 3 distinct problems:
 - Creating a Gem, and publishing it to Ruby Gems
 
 ## Creating a Jekyll Liquid Tag
-Jekyll liquid tags allow you to embed user-generated content safely. You might be okay with letting your users embed youtube videos, but you don't want them executing random javascript on your website. [Liquids](https://shopify.dev/docs/themes/liquid/reference/basics) are an extensible templating library designed by Shopify. You specify a tag type, and then pass your url or id, and the tag sanitizes it and embeds the content. {% comment %}{% twitch <clip url here> %}{% endcomment %}
+Jekyll liquid tags allow you to embed user-generated content safely. You might be okay with letting your users embed youtube videos, but you don't want them executing random javascript on your website. [Liquids](https://shopify.dev/docs/themes/liquid/reference/basics) are an extensible templating library designed by Shopify. You specify a tag type, and then pass your url or id, and the tag sanitizes it and embeds the content.
 
 >#### Examples:
->[Jekyll-YouTube](https://github.com/dommmel/jekyll-youtube)
->[Jekyll-Twitter](https://github.com/rob-murray/jekyll-twitter-plugin)
->[Jekyll-Gist](https://github.com/jekyll/jekyll-gist) (This one is maintained by Jekyll)
+>- [Jekyll-YouTube](https://github.com/dommmel/jekyll-youtube)
+>- [Jekyll-Twitter](https://github.com/rob-murray/jekyll-twitter-plugin)
+>- [Jekyll-Gist](https://github.com/jekyll/jekyll-gist) (This one is maintained by Jekyll)
 
 We'll start with Jekyll's guide to [liquid tags.](https://jekyllrb.com/docs/plugins/tags/) They say we should create a `TwitchTag` class inside the `Jekyll` module, and add a render method for the embeds. We also need to register the tag, `Liquid::Template.register_tag('twitch', Jekyll::TwitchTag)`, so Jekyll knows that it can use this tag.
 


### PR DESCRIPTION
# Description
Add the Jekyll-Twitch gem, so we can embed content from Twitch.

Also embed the twitch clip at the end of the first website blog.