### PR TITLE
Missing image for OS Contributing Talk

### DIFF
--- a/_posts/2021-11-11-open-source-contributing.md
+++ b/_posts/2021-11-11-open-source-contributing.md
@@ -4,9 +4,9 @@ layout: talk
 description: Do you find open-source intimidating? Let's fix that. Let's talk about how to get started in open-source.
 category: talks
 published: true
-thumbnail: "/assets/img/talks/open-source-contributing.jpg"
-image: "/assets/img/talks/open-source-contributing.jpg"
-feature-img: "/assets/img/talks/open-source-contributing.jpg"
+thumbnail: /assets/img/talks/open-source-contributing.jpg
+image: /assets/img/talks/open-source-contributing.jpg
+feature-img: /assets/img/talks/open-source-contributing.jpg
 twitter:
   card: summary_large_image
 ---


### PR DESCRIPTION
OS Talk is missing an image for the thumbnail in production. It's present in dev.