### PR TITLE
Update Publishing GitHub Action to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -12,5 +12,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: helaili/jekyll-action@v2
         with:
-          target_branch: 'gh-pages'
-          token: ${{ secrets.DEPLOY_SECRET }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Deploys were not working for chael.codes. Let's fix that!