### PR TITLE
Fix Deployment Workflow

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
-    - run: bundle install
+      with:
+        bundler-cache: true
     - name: Rubocop
       run: bundle exec rubocop


### PR DESCRIPTION
Let Ruby Setup handle installing and caching gems.

I had issues with environment permissions. I had to manually specify that this branch was allowed to deploy.
https://github.com/orgs/community/discussions/39054#discussioncomment-4134107